### PR TITLE
[BE] 리밸런스 기능 구현

### DIFF
--- a/BE/todo/src/main/java/team9/todo/controller/ApiCardController.java
+++ b/BE/todo/src/main/java/team9/todo/controller/ApiCardController.java
@@ -10,6 +10,7 @@ import team9.todo.domain.Card;
 import team9.todo.domain.DTO.Card.RequestCreateDTO;
 import team9.todo.domain.DTO.Card.RequestMoveDTO;
 import team9.todo.domain.DTO.Card.RequestUpdateDTO;
+import team9.todo.domain.DTO.Card.ResponseDTO;
 import team9.todo.domain.User;
 import team9.todo.domain.enums.CardColumn;
 import team9.todo.service.CardService;
@@ -72,7 +73,7 @@ public class ApiCardController {
     }
 
     @PutMapping("/move/{cardId}")
-    public ApiResult<Card> move(@PathVariable long cardId, @RequestBody RequestMoveDTO requestMoveDTO, HttpSession httpSession) {
+    public ApiResult<ResponseDTO> move(@PathVariable long cardId, @RequestBody RequestMoveDTO requestMoveDTO, HttpSession httpSession) {
         User user = getUser(httpSession);
 
         return ApiResult.succeed(cardService.move(cardId, requestMoveDTO.getPrevCardId(), requestMoveDTO.getNextCardId(), requestMoveDTO.getTo(), user));

--- a/BE/todo/src/main/java/team9/todo/controller/GlobalApiExceptionHandler.java
+++ b/BE/todo/src/main/java/team9/todo/controller/GlobalApiExceptionHandler.java
@@ -1,6 +1,8 @@
 package team9.todo.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team9.todo.domain.ApiResult;
 
@@ -9,6 +11,7 @@ public class GlobalApiExceptionHandler {
     @ExceptionHandler({
             RuntimeException.class
     })
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public ApiResult notAuthorizedException(RuntimeException exception) {
         return ApiResult.failed(exception);
     }

--- a/BE/todo/src/main/java/team9/todo/domain/DTO/Card/ResponseDTO.java
+++ b/BE/todo/src/main/java/team9/todo/domain/DTO/Card/ResponseDTO.java
@@ -6,8 +6,6 @@ import team9.todo.domain.enums.CardColumn;
 public class ResponseDTO {
     private Long id;
 
-    private long user; // TODO. IOS팀에게 쓰는지 여쭤보기
-
     private String title;
 
     private String content;
@@ -20,9 +18,8 @@ public class ResponseDTO {
 
     private boolean rebalanced;
 
-    private ResponseDTO(Long id, long user, String title, String content, double priority, CardColumn columnType, boolean deleted, boolean rebalanced) {
+    private ResponseDTO(Long id, String title, String content, double priority, CardColumn columnType, boolean deleted, boolean rebalanced) {
         this.id = id;
-        this.user = user;
         this.title = title;
         this.content = content;
         this.priority = priority;
@@ -32,17 +29,13 @@ public class ResponseDTO {
     }
 
     public static ResponseDTO of(Card entity, boolean rebalanced) {
-        return new ResponseDTO(entity.getId(), entity.getUser(), entity.getTitle(),
+        return new ResponseDTO(entity.getId(), entity.getTitle(),
                 entity.getContent(), entity.getPriority(),
                 entity.getColumnType(), entity.isDeleted(), rebalanced);
     }
 
     public Long getId() {
         return id;
-    }
-
-    public long getUser() {
-        return user;
     }
 
     public String getTitle() {

--- a/BE/todo/src/main/java/team9/todo/domain/DTO/Card/ResponseDTO.java
+++ b/BE/todo/src/main/java/team9/todo/domain/DTO/Card/ResponseDTO.java
@@ -1,0 +1,71 @@
+package team9.todo.domain.DTO.Card;
+
+import team9.todo.domain.Card;
+import team9.todo.domain.enums.CardColumn;
+
+public class ResponseDTO {
+    private Long id;
+
+    private long user; // TODO. IOS팀에게 쓰는지 여쭤보기
+
+    private String title;
+
+    private String content;
+
+    private double priority;
+
+    private CardColumn columnType;
+
+    private boolean deleted;
+
+    private boolean rebalanced;
+
+    private ResponseDTO(Long id, long user, String title, String content, double priority, CardColumn columnType, boolean deleted, boolean rebalanced) {
+        this.id = id;
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.priority = priority;
+        this.columnType = columnType;
+        this.deleted = deleted;
+        this.rebalanced = rebalanced; // 클라이언트에서 true 일때 카드목록을 전체 다 불러와야함.
+    }
+
+    public static ResponseDTO of(Card entity, boolean rebalanced) {
+        return new ResponseDTO(entity.getId(), entity.getUser(), entity.getTitle(),
+                entity.getContent(), entity.getPriority(),
+                entity.getColumnType(), entity.isDeleted(), rebalanced);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public long getUser() {
+        return user;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public double getPriority() {
+        return priority;
+    }
+
+    public CardColumn getColumnType() {
+        return columnType;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public boolean isRebalanced() {
+        return rebalanced;
+    }
+}

--- a/BE/todo/src/main/java/team9/todo/service/CardService.java
+++ b/BE/todo/src/main/java/team9/todo/service/CardService.java
@@ -135,4 +135,13 @@ public class CardService {
         return false;
     }
 
+    private void rebalancePriority(CardColumn cardColumn, User user) {
+        List<Card> cards = getList(cardColumn, user);
+        double priority = 0.0;
+        for (Card card : cards) {
+            priority += PRIORITY_STEP;
+            card.setPriority(priority);
+        }
+        cardRepository.saveAll(cards);
+    }
 }

--- a/BE/todo/src/main/java/team9/todo/service/CardService.java
+++ b/BE/todo/src/main/java/team9/todo/service/CardService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team9.todo.domain.Card;
+import team9.todo.domain.DTO.Card.ResponseDTO;
 import team9.todo.domain.History;
 import team9.todo.domain.User;
 import team9.todo.domain.enums.CardColumn;
@@ -81,7 +82,7 @@ public class CardService {
     }
 
     @Transactional
-    public Card move(long cardId, Long prevCardId, Long nextCardId, CardColumn to, User user) {
+    public ResponseDTO move(long cardId, Long prevCardId, Long nextCardId, CardColumn to, User user) {
         Card prevCard = null;
         Card nextCard = null;
         if (prevCardId != null) {
@@ -94,7 +95,8 @@ public class CardService {
         }
 
         double priority = renderPriority(prevCard, nextCard, to, user);
-        if (checkRebalance(priority, prevCard, nextCard)) {
+        boolean rebalanced;
+        if (rebalanced = checkRebalance(priority, prevCard, nextCard)) {
             rebalancePriority(to, user);
 
             prevCard = getCard(prevCardId, user);
@@ -114,7 +116,7 @@ public class CardService {
         if (from != to) {
             historyRepository.save(new History(saved.getId(), HistoryAction.MOVE, from, to));
         }
-        return saved;
+        return ResponseDTO.of(saved, rebalanced);
     }
 
     @Transactional

--- a/BE/todo/src/main/java/team9/todo/service/CardService.java
+++ b/BE/todo/src/main/java/team9/todo/service/CardService.java
@@ -124,4 +124,15 @@ public class CardService {
         card.validateOwner(user.getId());
         return card;
     }
+
+    private boolean checkRebalance(double renderedPriority, Card prevCard, Card nextCard) {
+        if (prevCard != null && renderedPriority == prevCard.getPriority()) {
+            return true;
+        }
+        if (nextCard != null && renderedPriority == nextCard.getPriority()) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/BE/todo/src/main/java/team9/todo/service/CardService.java
+++ b/BE/todo/src/main/java/team9/todo/service/CardService.java
@@ -63,7 +63,7 @@ public class CardService {
         return saved;
     }
 
-    private double renderPos(Card prevCard, Card nextCard) {
+    private double renderPriority(Card prevCard, Card nextCard, CardColumn cardColumn, User user) {
         double priority = 0.0;
         if (prevCard == null && nextCard != null) {
             priority = nextCard.getPriority() - PRIORITY_STEP;
@@ -73,6 +73,9 @@ public class CardService {
         }
         if (prevCard != null && nextCard != null) {
             priority = (prevCard.getPriority() + nextCard.getPriority()) / 2;
+        }
+        if (prevCard == null && nextCard == null) {
+            priority = getNextPriority(cardColumn, user);
         }
         return priority;
     }
@@ -90,10 +93,7 @@ public class CardService {
             nextCard.validateColumn(to);
         }
 
-        double priority = renderPos(prevCard, nextCard);
-        if (prevCard == null && nextCard == null) {
-            priority = getNextPriority(to, user);
-        }
+        double priority = renderPriority(prevCard, nextCard, to, user);
 
         logger.debug("{}번 카드 {}로 이동 요청, 계산된 priority=", cardId, to, priority);
 

--- a/BE/todo/src/main/java/team9/todo/service/CardService.java
+++ b/BE/todo/src/main/java/team9/todo/service/CardService.java
@@ -94,6 +94,13 @@ public class CardService {
         }
 
         double priority = renderPriority(prevCard, nextCard, to, user);
+        if (checkRebalance(priority, prevCard, nextCard)) {
+            rebalancePriority(to, user);
+
+            prevCard = getCard(prevCardId, user);
+            nextCard = getCard(nextCardId, user);
+            priority = renderPriority(prevCard, nextCard, to, user);
+        }
 
         logger.debug("{}번 카드 {}로 이동 요청, 계산된 priority=", cardId, to, priority);
 

--- a/BE/todo/src/main/resources/data.sql
+++ b/BE/todo/src/main/resources/data.sql
@@ -1,7 +1,7 @@
 INSERT INTO `user` (`user_id`,`password`) VALUES ('noel', '1234');
 INSERT INTO `card` (`user`, `title`, `content`, `priority`, `column_type`) VALUES (1, '제목입니다.', '내용입니다.', 1, 'TODO');
-INSERT INTO `card` (`USER`, `TITLE`, `CONTENT`, `PRIORITY`, `COLUMN_TYPE`) VALUES (1, '테스트1', '내용', 1.3, 'DOING');
-INSERT INTO `card` (`USER`, `TITLE`, `CONTENT`, `PRIORITY`, `COLUMN_TYPE`) VALUES (1, '테스트2', '내용', 1.6, 'DONE');
+INSERT INTO `card` (`USER`, `TITLE`, `CONTENT`, `PRIORITY`, `COLUMN_TYPE`) VALUES (1, '테스트1', '내용', 1.3, 'TODO');
+INSERT INTO `card` (`USER`, `TITLE`, `CONTENT`, `PRIORITY`, `COLUMN_TYPE`) VALUES (1, '테스트2', '내용', 1.6, 'TODO');
 INSERT INTO `history` (`CARD`, `ACTION`, `DATE`, `FROM`, `TO`) VALUES ('1', 'ADD', now(), null, 'TODO');
 INSERT INTO `history` (`CARD`, `ACTION`, `DATE`, `FROM`, `TO`) VALUES ('2', 'ADD', now(), null, 'DOING');
 INSERT INTO `history` (`CARD`, `ACTION`, `DATE`, `FROM`, `TO`) VALUES ('3', 'ADD', now(), null, 'DONE');

--- a/BE/todo/src/test/java/team9/todo/controller/ApiCardControllerTest.java
+++ b/BE/todo/src/test/java/team9/todo/controller/ApiCardControllerTest.java
@@ -1,4 +1,5 @@
 package team9.todo.controller;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,41 +9,49 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import team9.todo.domain.Card;
+import team9.todo.domain.DTO.Card.ResponseDTO;
 import team9.todo.domain.User;
 import team9.todo.domain.enums.CardColumn;
 import team9.todo.service.CardService;
+
 import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest
 @Transactional
 class ApiCardControllerTest {
     private CardService cardService;
+
     @Autowired
     public ApiCardControllerTest(CardService cardService) {
         this.cardService = cardService;
     }
+
     private Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+
     @Test
     @DisplayName("shuffle test")
     void move() {
         User user = new User("test", "1234");
         user.setId(1L);
         for (int i = 0; i < 1000; i++) {
-            System.err.println("cycle: "+i);
+            System.err.println("cycle: " + i);
             shuffleOneCycle(user);
         }
     }
+
     private void shuffleOneCycle(User user) {
-        Card card = cardService.move(3L, 1L, 2L, CardColumn.TODO, user);
-        System.err.println("priority: "+card.getPriority());
+        ResponseDTO responseDTO = cardService.move(3L, 1L, 2L, CardColumn.TODO, user);
+        System.err.println("priority: " + responseDTO.getPriority());
         List<Card> cards = cardService.getList(CardColumn.TODO, user);
         Assertions.assertAll(
                 () -> assertThat(cards.get(0).getId()).isEqualTo(1L),
                 () -> assertThat(cards.get(1).getId()).isEqualTo(3L),
                 () -> assertThat(cards.get(2).getId()).isEqualTo(2L)
         );
-        card = cardService.move(1L, 3L, 2L, CardColumn.TODO, user);
-        System.err.println("priority: "+card.getPriority());
+        responseDTO = cardService.move(1L, 3L, 2L, CardColumn.TODO, user);
+        System.err.println("priority: " + responseDTO.getPriority());
         List<Card> cards2 = cardService.getList(CardColumn.TODO, user);
         Assertions.assertAll(
                 () -> assertThat(cards2.get(0).getId()).isEqualTo(3L),

--- a/BE/todo/src/test/java/team9/todo/controller/ApiCardControllerTest.java
+++ b/BE/todo/src/test/java/team9/todo/controller/ApiCardControllerTest.java
@@ -1,0 +1,53 @@
+package team9.todo.controller;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import team9.todo.domain.Card;
+import team9.todo.domain.User;
+import team9.todo.domain.enums.CardColumn;
+import team9.todo.service.CardService;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+@SpringBootTest
+@Transactional
+class ApiCardControllerTest {
+    private CardService cardService;
+    @Autowired
+    public ApiCardControllerTest(CardService cardService) {
+        this.cardService = cardService;
+    }
+    private Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+    @Test
+    @DisplayName("shuffle test")
+    void move() {
+        User user = new User("test", "1234");
+        user.setId(1L);
+        for (int i = 0; i < 1000; i++) {
+            System.err.println("cycle: "+i);
+            shuffleOneCycle(user);
+        }
+    }
+    private void shuffleOneCycle(User user) {
+        Card card = cardService.move(3L, 1L, 2L, CardColumn.TODO, user);
+        System.err.println("priority: "+card.getPriority());
+        List<Card> cards = cardService.getList(CardColumn.TODO, user);
+        Assertions.assertAll(
+                () -> assertThat(cards.get(0).getId()).isEqualTo(1L),
+                () -> assertThat(cards.get(1).getId()).isEqualTo(3L),
+                () -> assertThat(cards.get(2).getId()).isEqualTo(2L)
+        );
+        card = cardService.move(1L, 3L, 2L, CardColumn.TODO, user);
+        System.err.println("priority: "+card.getPriority());
+        List<Card> cards2 = cardService.getList(CardColumn.TODO, user);
+        Assertions.assertAll(
+                () -> assertThat(cards2.get(0).getId()).isEqualTo(3L),
+                () -> assertThat(cards2.get(1).getId()).isEqualTo(1L),
+                () -> assertThat(cards2.get(2).getId()).isEqualTo(2L)
+        );
+    }
+}


### PR DESCRIPTION
테스트 코드를 통해 카드 이동을 1000번 해본 결과, 특정 사이클을 기점으로 priority가 중복돼 더이상 카드별로 priority를 비교 할 수 없게 됐다.

![image-20210415151213028](https://user-images.githubusercontent.com/73760074/114958800-b98d5200-9e9e-11eb-87b0-e320e2168ad4.png)


## 아이디어

나: 

- ~~소수점  자리 수를 새서 double의 한계치에 도달하기 전에 리밸런싱 ⛔~~
- 리밸런싱할 소수점 자리의 기준을 정하기 애매함.

아이작: 

- move 메소드 내에서 계산된 priority값이 prevCard.priority 또는 nextCard.priority과 같아질 때 리밸런싱 ✅

```java
private boolean checkRebalance(double renderedPriority, Card prevCard, Card nextCard) {
        if (prevCard != null && renderedPriority == prevCard.getPriority()) {
            return true;
        }
        if (nextCard != null && renderedPriority == nextCard.getPriority()) {
            return true;
        }
        return false;
    }

private void rebalancePriority(CardColumn cardColumn, User user) {
        List<Card> cards = getList(cardColumn, user);
        double priority = 0.0;
        for (Card card : cards) {
            priority += PRIORITY_STEP;
            card.setPriority(priority);
        }
        cardRepository.saveAll(cards);
    }

```

```java
# card를 move 하는 메소드 내부 로직중..

if (rebalanced = checkRebalance(priority, prevCard, nextCard)) {
    rebalancePriority(to, user);

    prevCard = getCard(prevCardId, user); //리밸런싱후 기존 카드들의 정렬순서를 보장하기 위함
    nextCard = getCard(nextCardId, user); // ..
    priority = renderPriority(prevCard, nextCard, to, user); // ..
}
```

`겹치지 않고 테스트 성공!` 

![image-20210415171619660](https://user-images.githubusercontent.com/73760074/114958815-be520600-9e9e-11eb-9ef7-228b569a72a4.png)